### PR TITLE
Clean build folder each time to prevent cruft

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,7 +79,7 @@ gulp.task('import-docs', function() {
 /* Generate Pattern Library with Metalsmith */
 gulp.task('pattern-library', ['import-docs'], function() {
   metalsmith(dir.base)
-    .clean(!devBuild) // clean folder before a production build
+    .clean(true) // clean folder before build
     .source(dir.src) // source folder (src/)
     .destination(dir.dest) // build folder (build/)
     .use(collections({


### PR DESCRIPTION
## Done

When switching between branches on `vanilla-framework` I noticed that I was still seeing docs in my local vf.io from branches other than the one I was currently on.

This change will nuke the build folder before each build.
## QA

Run both projects side-by-side with `gulp develop` and observe the `build` folder regenerating as you save changes to markdown files in `vanilla-framework`.
