### PR TITLE
A script to run gulp through docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /build/
-/node_modules/
 /src/docs/
+npm-debug.log

--- a/run-gulp
+++ b/run-gulp
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+docker run -ti --volume vfio-dependencies:/packages/node_modules --volume `pwd`:/app ubuntudesign/node:v1.0.2 gulp import-docs
+docker run -ti -p 3000:3000 --volume vfio-dependencies:/packages/node_modules --volume `pwd`:/app ubuntudesign/node:v1.0.2 gulp develop
+


### PR DESCRIPTION
Make use of ubuntudesign/node to build docs and run gulp in a nice simple encapsulated way.

This is sort of experimental. It occurred to me that ubuntudesign/node does give us a simple way to encapsulate node dependencies pretty easily. So this is just a sort of prototype for how to do that well.
## QA

``` bash
./run-gulp
```

After installing dependencies, the site should be running on http://localhost:3000.
