### PR TITLE
Don't open browser window when running `develop`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,8 @@ gulp.task('help', function() {
 gulp.task('browser-sync', function() {
     browserSync.init({
         server: {
-            baseDir: "./build"
+            baseDir: "./build",
+            noOpen: true
         }
     });
 


### PR DESCRIPTION
I find that opening a browser window on every run can cause a frustrating experience. I would like to remove this behaviour as default, pending on other people's thoughts on this matter.

The terminal output provides a link in the terminal to open manually, or you can keep using the existing window.
