### PR TITLE
Catch Gulp pipe exceptions with Plumber

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,6 +44,7 @@ concat = require('gulp-concat'),
 browserSync = require('browser-sync').create(),
 reload      = browserSync.reload,
 ghPages = require('gulp-gh-pages'),
+plumber = require('gulp-plumber'),
 // Metalmsith - pattern library generation
 metalsmith = require('metalsmith'),
 markdown   = require('metalsmith-markdown'),
@@ -128,6 +129,7 @@ gulp.task('sass-build', function() {
 
 gulp.task('sass-develop', function() {
   return gulp.src(['scss/**/*.scss'])
+    .pipe(plumber())
     .pipe(sass({
       includePaths: ['node_modules']
     }))

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gulp-cssnano": "^2.1.2",
     "gulp-gh-pages": "^0.5.4",
     "gulp-notify": "2.2.0",
+    "gulp-plumber": "^1.1.0",
     "gulp-rename": "1.2.2",
     "gulp-sass": "2.3.2",
     "gulp-scss-lint": "0.4.0",


### PR DESCRIPTION
Catch exceptions with Plumber, so that watch and develop gulp commands do not need to be restarted on an error.
