### PR TITLE
Update sidebar link styles

### DIFF
--- a/src/partials/sidebar.hbt
+++ b/src/partials/sidebar.hbt
@@ -7,7 +7,7 @@
             <ul class="p-sidebar-nav__list">
                 {{#each collections.settings}}
                     <li>
-                        <a class="p-sidebar-nav__link" href="/{{this.path}}">
+                        <a class="p-link--soft" href="/{{this.path}}">
                             {{this.title}}
                         </a>
                     </li>
@@ -23,7 +23,7 @@
             <ul class="p-sidebar-nav__list">
                 {{#each collections.base}}
                     <li>
-                        <a class="p-sidebar-nav__link" href="/{{this.path}}">
+                        <a class="p-link--soft" href="/{{this.path}}">
                             {{this.title}}
                         </a>
                     </li>
@@ -39,7 +39,7 @@
             <ul class="p-sidebar-nav__list">
                 {{#each collections.patterns}}
                     <li>
-                        <a class="p-sidebar-nav__link" href="/{{this.path}}">
+                        <a class="p-link--soft" href="/{{this.path}}">
                             {{this.title}}
                         </a>
                     </li>
@@ -55,7 +55,7 @@
             <ul class="p-sidebar-nav__list">
                 {{#each collections.utilities}}
                     <li>
-                        <a class="p-sidebar-nav__link" href="/{{this.path}}">
+                        <a class="p-link--soft" href="/{{this.path}}">
                             {{this.title}}
                         </a>
                     </li>


### PR DESCRIPTION
## Done

- Made sidebar link styles "soft"

## QA

- Pull code
- Run `gulp develop`
- Check that sidebar links are using 'soft' style

## Related

Fixes https://github.com/vanilla-framework/vanilla-docs-theme/issues/23