### PR TITLE
Bump example-js to version 1.0.2

### DIFF
--- a/template.html
+++ b/template.html
@@ -526,6 +526,6 @@
         );
       }
     </script>
-    <script src="https://assets.ubuntu.com/v1/f030c16d-example-1.0.1.js"></script>
+    <script src="https://assets.ubuntu.com/v1/82a5ae3a-example-1.0.2.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Done
- Simply bumped the version of example-js to v1.0.2

## QA
- Check it is the same asset mentioned in the release notes [1]

[1] https://github.com/vanilla-framework/example-js/releases