### PR TITLE
Bumped the version of example js to 1.0.3

### DIFF
--- a/template.html
+++ b/template.html
@@ -528,6 +528,6 @@
         );
       }
     </script>
-    <script src="https://assets.ubuntu.com/v1/82a5ae3a-example-1.0.2.js"></script>
+    <script src="https://assets.ubuntu.com/v1/4d0f17e6-example-1.0.3.js"></script>
   </body>
 </html>

--- a/template.html
+++ b/template.html
@@ -242,7 +242,6 @@
       <div class="p-navigation__logo">
         {% if site_root %}<a class="p-navigation__link" href="{{ site_root }}">{% endif %}
           {% if site_logo_url %}<img class="p-navigation__image" src="{{ site_logo_url }}" alt="{{ site_title }} logo" />{% endif %}
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg" />
           {{ site_title if site_title else 'Documentation' }}
         {% if site_root %}</a>{% endif %}
       </div>


### PR DESCRIPTION
## Done
Updated example-js to v1.0.3. Brive by to remove the placeholder logo. The expected behaviour with no docs logo would be to have none.

## QA
- Pull down branch
- Run `curl https://getcaddy.com/ | bash` if not already installed
- Run `./build-html`
- Run `caddy`
- Go to http://127.0.0.1:8543/en/base/forms
- Check code is ok
- Check the example show ok
 - With syntax highlighting and correct height
- Check there is only a single logo

## Details
Fixes https://github.com/canonical-webteam/example-js/issues/21