### PR TITLE
Remove breadcrumbs

### DIFF
--- a/template.html
+++ b/template.html
@@ -435,15 +435,6 @@
           expandCollapseAll(document.querySelectorAll('.p-sidebar-nav li'));
           </script>
         </div>
-        <nav class="p-breadcrumbs">
-          {% for breadcrumb in breadcrumbs %}
-            {% if breadcrumb.active or not breadcrumb.location %}
-              <span class="p-breadcrumbs__link">{{ breadcrumb.title }}</span>
-            {% else %}
-              <a class="p-breadcrumbs__link" href="{{ breadcrumb.location }}">{{ breadcrumb.title }}</a>
-            {% endif %}
-          {% endfor %}
-        </nav>
         {% endif %}
         <div class="col-12 p-layout__main">
           <main id="main-content" class="p-layout__inner">


### PR DESCRIPTION
## Done
Removed breadcrumb links from small screens. As none of the navigation items link and therefore is misleading to the user. 

[Further explanation on the related issue](https://github.com/vanilla-framework/vanilla-docs-theme/issues/37#issuecomment-297317509)

## QA
- Pull this code and run:
```bash
./build-html
caddy
```
- Go to http://127.0.0.1:8543/en/patterns/breadcrumbs
- Shrink your screen to small screen
- Check that there are no breadcrumbs

## Details
Fixes https://github.com/vanilla-framework/vanilla-docs-theme/issues/37

## Screenshot
![documentation](https://cloud.githubusercontent.com/assets/1413534/25428000/3fea7266-2a6c-11e7-815b-363a60f25f84.png)
