### PR TITLE
Only build released documentation

### DIFF
--- a/build-html
+++ b/build-html
@@ -1,5 +1,5 @@
 rm -rf vanilla-framework
-git clone https://github.com/vanilla-framework/vanilla-framework
+git clone https://github.com/vanilla-framework/vanilla-framework --branch master
 documentation-builder --base-directory vanilla-framework/docs  \
                       --site-root '/en/'  \
                       --output-path .  \


### PR DESCRIPTION
## Done
Clone the master (released) branch when building the docs.

## QA
- Pull down this branch
- Run `./build-html`
- Run `cat en/patterns/navigation.html | grep 'Fixed width navigation'`
- Make it returns a h2 element

_The [navigation documentation in develop](https://github.com/vanilla-framework/vanilla-framework/blob/develop/docs/en/patterns/navigation.md) (default branch) has been modified. Removing the fixed and full sections_