### PR TITLE
Upgrade example-js to 1.0.4

### DIFF
--- a/template.html
+++ b/template.html
@@ -518,6 +518,6 @@
         );
       }
     </script>
-    <script src="https://assets.ubuntu.com/v1/4d0f17e6-example-1.0.3.js"></script>
+    <script src="https://assets.ubuntu.com/v1/dede3e18-example-1.0.4.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Done
Upgraded example-js from 1.0.3 to 1.0.4

## QA
- Pull down this branch
- Run `./build-html`
- Run `caddy`
- Go to http://127.0.0.1:8543/en/
- Check the examples are displayed correctly and with some padding unlike on live

## Details
Fixes https://github.com/ubuntudesign/docs.vanillaframework.io/issues/96

