### PR TITLE
Add vanilla-brochure-theme docs

### DIFF
--- a/build-html
+++ b/build-html
@@ -24,14 +24,14 @@ rm -rf vanilla-brochure-theme
 git clone https://github.com/vanilla-framework/vanilla-brochure-theme
 documentation-builder --base-directory vanilla-brochure-theme/docs \
                       --site-root '/en/' \
-                      --output-path 'en/themes/vanilla-brochure-theme' \
+                      --output-path 'en/vanilla-brochure-theme' \
                       --template-path template.html \
                       --tag-manager-code 'GTM-K92JCQ'  \
                       --no-link-extensions \
                       --force
 
-mv en/themes/vanilla-brochure-theme/en/* en/themes/vanilla-brochure-theme/.
-rm -rf en/themes/vanilla-brochure-theme/en/
+mv en/vanilla-brochure-theme/en/* en/vanilla-brochure-theme/.
+rm -rf en/vanilla-brochure-theme/en/
 rm -rf vanilla-brochure-theme
 echo "${GREEN}Completed vanilla-brochure-theme documentation build${NC}"
 

--- a/build-html
+++ b/build-html
@@ -1,3 +1,12 @@
+BLUE='\033[1;34m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+echo "${BLUE}Clearing build${NC}"
+rm -rf en
+echo "${GREEN}Build removed${NC}"
+
+echo "${BLUE}Building vanilla-frameworks documentation${NC}"
 rm -rf vanilla-framework
 git clone https://github.com/vanilla-framework/vanilla-framework
 documentation-builder --base-directory vanilla-framework/docs  \
@@ -8,4 +17,21 @@ documentation-builder --base-directory vanilla-framework/docs  \
                       --no-link-extensions \
                       --force
 rm -rf vanilla-framework
+echo "${GREEN}Completed vanilla-framework documentation build${NC}"
+
+echo "${BLUE}Build vanilla-brochure-theme documentation${NC}"
+rm -rf vanilla-brochure-theme
+git clone https://github.com/vanilla-framework/vanilla-brochure-theme
+documentation-builder --base-directory vanilla-brochure-theme/docs \
+                      --site-root '/en/' \
+                      --output-path 'en/themes/vanilla-brochure-theme' \
+                      --template-path template.html \
+                      --tag-manager-code 'GTM-K92JCQ'  \
+                      --no-link-extensions \
+                      --force
+
+mv en/themes/vanilla-brochure-theme/en/* en/themes/vanilla-brochure-theme/.
+rm -rf en/themes/vanilla-brochure-theme/en/
+rm -rf vanilla-brochure-theme
+echo "${GREEN}Completed vanilla-brochure-theme documentation build${NC}"
 


### PR DESCRIPTION
## Done
Added vanilla-brochure-theme documentation to the build steps.

## QA
- Pull down this branch
- Run `./build-html`
- Run `caddy`
- Go to http://127.0.0.1:8543/en/ and check the Vanilla documentation is correct
- Go to http://127.0.0.1:8543/en/themes/vanilla-brochure-theme/ and check the docs and see the theme docs are correct

## Details
Fixes https://github.com/ubuntudesign/docs.vanillaframework.io/issues/95

