### PR TITLE
Fix the homepage link to brochure theme docs

### DIFF
--- a/build-html
+++ b/build-html
@@ -23,7 +23,7 @@ echo "${BLUE}Build vanilla-brochure-theme documentation${NC}"
 rm -rf vanilla-brochure-theme
 git clone https://github.com/vanilla-framework/vanilla-brochure-theme
 documentation-builder --base-directory vanilla-brochure-theme/docs \
-                      --site-root '/en/' \
+                      --site-root '/en/vanilla-brochure-theme/index' \
                       --output-path 'en/vanilla-brochure-theme' \
                       --template-path template.html \
                       --tag-manager-code 'GTM-K92JCQ'  \


### PR DESCRIPTION
## Done
Update the homepage link of brochure theme docs

## QA
- Pull down this branch
- Run `./build-html`
- Run `caddy`
- Go to http://127.0.0.1:8543/en/themes/vanilla-brochure-theme/index
- Click the header logo and see it links to the homepage of the brochure docs

Fixes https://github.com/ubuntudesign/docs.vanillaframework.io/issues/102