### PR TITLE
Set the header title to Documentation

### DIFF
--- a/template.html
+++ b/template.html
@@ -12,7 +12,7 @@
     {% endif %}
 
     <meta charset="UTF-8" />
-    <title>{{ site_title if site_title else 'Documentation' }}</title>
+    <title>{{ title }} | {{ site_title if site_title else 'Documentation' }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="{{ site_favicon }}" type="image/x-icon" />
     <style>
@@ -242,7 +242,7 @@
       <div class="p-navigation__logo">
         {% if site_root %}<a class="p-navigation__link" href="{{ site_root }}">{% endif %}
           {% if site_logo_url %}<img class="p-navigation__image" src="{{ site_logo_url }}" alt="{{ site_title }} logo" />{% endif %}
-          Documentation
+          {{ site_title if site_title else 'Documentation' }}
         {% if site_root %}</a>{% endif %}
       </div>
       <label for="nav-toggle-checkbox" class="theme__sidebar-toggle-button">Menu</label>

--- a/template.html
+++ b/template.html
@@ -242,7 +242,7 @@
       <div class="p-navigation__logo">
         {% if site_root %}<a class="p-navigation__link" href="{{ site_root }}">{% endif %}
           {% if site_logo_url %}<img class="p-navigation__image" src="{{ site_logo_url }}" alt="{{ site_title }} logo" />{% endif %}
-          {{ site_title if site_title else 'Documentation' }}
+          Documentation
         {% if site_root %}</a>{% endif %}
       </div>
       <label for="nav-toggle-checkbox" class="theme__sidebar-toggle-button">Menu</label>


### PR DESCRIPTION
## Done
Removed the dynamic header title and set it to `Documentation` at all times.

## QA
- Pull down code
- Run `./build-html`
- Run `caddy`
- Open http://127.0.0.1:8543/en/
- Navigate around the docs and check the title next to the logo says Documentation all the time

## Details
Fixes https://github.com/ubuntudesign/docs.vanillaframework.io/issues/93

## Screenshots
![code - vanilla framework documentation](https://user-images.githubusercontent.com/1413534/28086978-be4cd228-6678-11e7-8f1e-65f7af1de86c.png)

