### PR TITLE
Remove brochure docs from the build

### DIFF
--- a/build-html
+++ b/build-html
@@ -19,19 +19,3 @@ documentation-builder --base-directory vanilla-framework/docs  \
 rm -rf vanilla-framework
 echo "${GREEN}Completed vanilla-framework documentation build${NC}"
 
-echo "${BLUE}Build vanilla-brochure-theme documentation${NC}"
-rm -rf vanilla-brochure-theme
-git clone https://github.com/vanilla-framework/vanilla-brochure-theme
-documentation-builder --base-directory vanilla-brochure-theme/docs \
-                      --site-root '/en/vanilla-brochure-theme/index' \
-                      --output-path 'en/vanilla-brochure-theme' \
-                      --template-path template.html \
-                      --tag-manager-code 'GTM-K92JCQ'  \
-                      --no-link-extensions \
-                      --force
-
-mv en/vanilla-brochure-theme/en/* en/vanilla-brochure-theme/.
-rm -rf en/vanilla-brochure-theme/en/
-rm -rf vanilla-brochure-theme
-echo "${GREEN}Completed vanilla-brochure-theme documentation build${NC}"
-


### PR DESCRIPTION
## Done
Remove brochure docs from the build

## QA
- Pull code
- Run `./build-html`
- Run `caddy`
- Go to http://127.0.0.1:8543/en/
- Check that the link to the brochure-theme 404s as this change needs to be made in the framework code base

